### PR TITLE
Update xml-rs to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["confluence", "atlassian", "api", "soap", "wiki"]
 categories = ["api-bindings"]
 
 [dependencies]
-xml-rs = "0.7"
+xml-rs = "0.8"
 log = "0.4"
 reqwest = "0.9"
 xmltree = "0.8"


### PR DESCRIPTION
Compiles with `1.34.2-x86_64-unknown-linux-gnu`, and did work with some small test code of mine that does perform a login. confluence-rs does not expose any types from xml-rs, does it?