### PR TITLE
Use try/? instead of unwrap in HTTP requests

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -15,7 +15,7 @@ pub struct Response {
 
 /// Perform a GET request to specified URL.
 pub fn get(url: &str) -> Result<Response> {
-    let mut res = reqwest::get(url).unwrap();
+    let mut res = reqwest::get(url)?;
     let mut body = String::new();
     res.read_to_string(&mut body).unwrap();
     let status = res.status();
@@ -36,8 +36,7 @@ pub fn soap_action(url: &str, action: &str, xml: &str) -> Result<Response> {
         .post(url)
         .headers(hmap)
         .body(xml.to_string())
-        .send()
-        .unwrap();
+        .send()?;
 
     let mut body = String::new();
     response.read_to_string(&mut body).unwrap();


### PR DESCRIPTION
Compiles with `1.34.2-x86_64-unknown-linux-gnu`.

Found some unwrap()s which could be replaced by `?` because the error type already fits. unwrap() on IO calls should be avoided anyway.