### PR TITLE
Deal with empty pages

### DIFF
--- a/src/transforms.rs
+++ b/src/transforms.rs
@@ -34,7 +34,10 @@ impl FromElement for Page {
             version: element.get_at_path(&["version"]).and_then(|e| e.as_int())?,
             content: element
                 .get_at_path(&["content"])
-                .and_then(|e| e.as_string())?,
+                .and_then(|e|
+                    e.as_string()
+                        .or(Ok(String::new()))
+                )?,
             created: element
                 .get_at_path(&["created"])
                 .and_then(|e| e.as_datetime())?,


### PR DESCRIPTION
* If a Confluence page is empty, return an empty string